### PR TITLE
Use Rust 1.85 as the MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.82"
+  RUST_MIN_VER: "1.85"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
   RUST_MIN_VER_PKGS: "-p tabulon"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find its changes [documented below](#0XY-2025-01-01).
 
 ## [Unreleased]
 
-This release has an [MSRV][] of 1.82.
+This release has an [MSRV][] of 1.85.
 
 This is the initial release.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ version = "0.1.0"
 edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
-# When updating to 1.84 or later, update `tabulon/src/floatfuncs.rs` and remove this note.
-rust-version = "1.82"
+rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/tabulon"
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Tabulon library provides functionality for working with canvas-like scenes.
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Tabulon has been verified to compile with **Rust 1.82** and later.
+This version of Tabulon has been verified to compile with **Rust 1.85** and later.
 
 Future versions of Tabulon might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/tabulon/src/floatfuncs.rs
+++ b/tabulon/src/floatfuncs.rs
@@ -1,14 +1,6 @@
 // Copyright 2024 the Tabulon Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// In Rust 1.84 (https://github.com/rust-lang/rust/pull/131304), `abs` and
-// `copysign` were added to `core`, so we no longer need these forwarded to
-// libm.
-#![cfg_attr(
-    not(feature = "std"),
-    allow(dead_code, reason = "abs and copysign were added to core in 1.84")
-)]
-
 //! Shims for math functions that ordinarily come from std.
 
 /// Defines a trait that chooses between libstd or libm implementations of float methods.
@@ -23,6 +15,7 @@ macro_rules! define_float_funcs {
         /// the `std` feature is not enabled.
         ///
         /// For documentation see the respective functions in the std library.
+        #[expect(dead_code, reason = "This is here for future use, isn't used yet.")]
         #[cfg(not(feature = "std"))]
         pub(crate) trait FloatFuncs : Sized {
             $(fn $name(self $(,$arg: $arg_ty)*) -> $ret;)+
@@ -43,13 +36,9 @@ macro_rules! define_float_funcs {
 }
 
 define_float_funcs! {
-    // This is not needed once the MSRV is 1.84 or later.
-    fn abs(self) -> Self => fabsf;
     fn atan2(self, other: Self) -> Self => atan2f;
     fn cbrt(self) -> Self => cbrtf;
     fn ceil(self) -> Self => ceilf;
-    // This is not needed once the MSRV is 1.84 or later.
-    fn copysign(self, sign: Self) -> Self => copysignf;
     fn floor(self) -> Self => floorf;
     fn hypot(self, other: Self) -> Self => hypotf;
     // Note: powi is missing because its libm implementation is not efficient


### PR DESCRIPTION
By the time this is released, this won't be the most recent version and it'll let us switch to 2024 edition.