### PR TITLE
vello_viewer: Add basic panning and zooming with primary cursor.

### DIFF
--- a/tabulon/src/graphics_bag.rs
+++ b/tabulon/src/graphics_bag.rs
@@ -16,7 +16,8 @@ pub enum GraphicsItem {
 /// Bag of [`GraphicsItem`]s.
 #[derive(Debug, Default)]
 pub struct GraphicsBag {
-    items: Vec<GraphicsItem>,
+    /// [`GraphicsItem`]s in the bag.
+    pub items: Vec<GraphicsItem>,
 }
 
 impl GraphicsBag {


### PR DESCRIPTION
This also restructures things so the DXF file is loaded once, so that the graphics bag is constructed once, and so that transforms don't cause everything to be recomputed.

It also enables a more interactive present mode, which improves responsiveness.
