### PR TITLE
tabulon_dxf: Correct Arc translation.

### DIFF
--- a/tabulon/src/shape.rs
+++ b/tabulon/src/shape.rs
@@ -93,8 +93,12 @@ impl AnyShape {
         impl_any_shape_generic_transform!(
             self,
             transform,
-            CircleSegment | Rect | RoundedRect,
-            Arc | BezPath | Circle | CubicBez | Ellipse | Line | PathSeg | QuadBez
+            // I ran into issues with the `Affine` multiplication implementation
+            // on `Arc` in this context, but it behaves correctly after it is
+            // converted to a `BezPath` before transforming.
+            // Can move this down to the direct impls if/when that is fixed.
+            Arc | CircleSegment | Rect | RoundedRect,
+            BezPath | Circle | CubicBez | Ellipse | Line | PathSeg | QuadBez
         )
     }
 

--- a/tabulon_dxf/src/lib.rs
+++ b/tabulon_dxf/src/lib.rs
@@ -39,10 +39,12 @@ pub fn shape_from_entity(e: &dxf::entities::Entity) -> Option<AnyShape> {
                         x: center.x,
                         y: center.y,
                     },
-                    radii: Vec2::new(radius, radius),
-                    start_angle,
-                    // FIXME: don't know if this is correct.
-                    sweep_angle: end_angle,
+                    radii: Vec2 {
+                        x: radius,
+                        y: radius,
+                    },
+                    start_angle: start_angle.to_radians(),
+                    sweep_angle: (end_angle - start_angle).rem_euclid(360.0).to_radians(),
                     x_rotation: 0.0,
                 }
                 .into(),


### PR DESCRIPTION
Angles in dxf-rs are in degrees, but angles in Kurbo are in radians, and the start and end angles are used instead of sweep angles. These are now correctly calculated for Kurbo use.

Correctly translating the angles dramatically improves performance because Arcs are now 360 times shorter, thus generate fewer segments.

`Arc` is moved to the set of shapes that are converted to paths before being transformed, because I was getting incorrect results from `Affine` multiplication with `kurbo::Arc`.