### PR TITLE
tabulon_dxf: Derive MTEXT alignment from attachment point.

### DIFF
--- a/tabulon_vello/src/lib.rs
+++ b/tabulon_vello/src/lib.rs
@@ -107,7 +107,7 @@ impl Environment {
                         layout.break_all_lines(*max_inline_size);
                         layout.align(*max_inline_size, *alignment, Default::default());
                         let layout_size = Size {
-                            width: layout.width() as f64,
+                            width: max_inline_size.unwrap_or(layout.width()) as f64,
                             height: layout.height() as f64,
                         };
 


### PR DESCRIPTION
MTEXT derives its default inline alignment from the attachment point, so I've added that.

Previously I was interpreting `reference_rectangle_width` as the reflow width of the MTEXT, it turns out that this is a cached parameter like `vertical_height`.

`column_width` is the correct reflow width for MTEXTs.