### PR TITLE
Use `sync::Arc` to reference `AnyShape`s, and restructure.

### DIFF
--- a/examples/vello_simple/src/main.rs
+++ b/examples/vello_simple/src/main.rs
@@ -212,7 +212,9 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
                 stroke_paint: Some(Color::new([0.9804, 0.702, 0.5294, 1.]).into()),
                 fill_paint: None,
             },
-            subshapes: SmallVec::from([RoundedRect::new(10.0, 10.0, 240.0, 240.0, 20.0).into()]),
+            subshapes: SmallVec::from([Arc::new(
+                RoundedRect::new(10.0, 10.0, 240.0, 240.0, 20.0).into(),
+            )]),
         },
     );
 
@@ -226,7 +228,7 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
                 stroke_paint: None,
                 fill_paint: Some(Color::new([0.9529, 0.5451, 0.6588, 1.]).into()),
             },
-            subshapes: SmallVec::from([Circle::new((420.0, 200.0), 120.0).into()]),
+            subshapes: SmallVec::from([Arc::new(Circle::new((420.0, 200.0), 120.0).into())]),
         },
     );
 
@@ -240,7 +242,9 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
                 stroke_paint: None,
                 fill_paint: Some(Color::new([0.7961, 0.651, 0.9686, 1.]).into()),
             },
-            subshapes: SmallVec::from([Ellipse::new((250.0, 420.0), (100.0, 160.0), -90.0).into()]),
+            subshapes: SmallVec::from([Arc::new(
+                Ellipse::new((250.0, 420.0), (100.0, 160.0), -90.0).into(),
+            )]),
         },
     );
 
@@ -254,7 +258,7 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
                 stroke_paint: Some(Color::new([0.5373, 0.7059, 0.9804, 1.]).into()),
                 fill_paint: None,
             },
-            subshapes: SmallVec::from([Line::new((260.0, 20.0), (620.0, 100.0)).into()]),
+            subshapes: SmallVec::from([Arc::new(Line::new((260.0, 20.0), (620.0, 100.0)).into())]),
         },
     );
 

--- a/tabulon/src/shape.rs
+++ b/tabulon/src/shape.rs
@@ -13,6 +13,9 @@ pub use smallvec::SmallVec;
 #[cfg(all(not(feature = "std"), not(test)))]
 use crate::floatfuncs::FloatFuncs;
 
+extern crate alloc;
+use alloc::sync;
+
 /// Enumeration of Kurbo shapes supported in `FatShape`.
 #[derive(Debug, Clone)]
 pub enum AnyShape {
@@ -214,7 +217,7 @@ pub struct FatShape {
     /// Paint information
     pub paint: FatPaint,
     /// [`AnyShape`]s
-    pub subshapes: SmallVec<[AnyShape; 1]>,
+    pub subshapes: SmallVec<[sync::Arc<AnyShape>; 1]>,
 }
 
 impl FatShape {
@@ -223,7 +226,7 @@ impl FatShape {
         self.subshapes.get(1).map(|s| {
             self.subshapes
                 .iter()
-                .map(AnyShape::bounding_box)
+                .map(|x| x.bounding_box())
                 .fold(s.bounding_box(), |a, x| a.union(x))
         })
     }

--- a/tabulon/src/text.rs
+++ b/tabulon/src/text.rs
@@ -15,7 +15,7 @@ use crate::DirectIsometry;
 
 /// Reference point where text is attached to an insertion point.
 #[repr(i32)]
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum AttachmentPoint {
     /// Top left corner.
     #[default]
@@ -66,7 +66,7 @@ impl AttachmentPoint {
 }
 
 /// Text item.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FatText {
     /// Primary transform.
     pub transform: Affine,

--- a/tabulon_vello/src/lib.rs
+++ b/tabulon_vello/src/lib.rs
@@ -51,7 +51,7 @@ impl Environment {
                     fill_paint,
                 } = $paint;
 
-                match $subshape {
+                match &**$subshape {
                     $(AnyShape::$name(x) =>  {
                         if let Some(fill_paint) = fill_paint {
                             scene.fill(NonZero, *$transform, fill_paint, None, &x);


### PR DESCRIPTION
Putting shapes in `Arc` can make a lot of functionality much simpler, and doesn't (currently) cost a measurable amount of performance. The end goal is NOT to have an `Arc` per shape however, but rather on collections of static geometry.
This also switches `vello_viewer` to debug printing the `Entity` that was picked, rather than the shape that was picked, this is a step toward surfacing more interesting information through `tabulon_dxf` to display on screen and to wire into gizmos (layer list, entity info box, etc.).