### PR TITLE
Introduce managed transforms on `GraphicsBag`.

### DIFF
--- a/examples/vello_simple/src/main.rs
+++ b/examples/vello_simple/src/main.rs
@@ -7,7 +7,7 @@
 use anyhow::Result;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use vello::kurbo::{Affine, Circle, Ellipse, Line, RoundedRect, Stroke};
+use vello::kurbo::{Circle, Ellipse, Line, RoundedRect, Stroke};
 use vello::peniko::color::palette;
 use vello::peniko::Color;
 use vello::util::{RenderContext, RenderSurface};
@@ -196,7 +196,7 @@ fn create_vello_renderer(render_cx: &RenderContext, surface: &RenderSurface<'_>)
 /// Add shapes to a vello scene. This does not actually render the shapes, but adds them
 /// to the Scene data structure which represents a set of objects to draw.
 fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &mut Scene) {
-    use tabulon::shape::{FatPaint, FatShape, SmallVec};
+    use tabulon::shape::{FatPaint, FatShape};
     use tabulon::{graphics_bag::GraphicsBag, render_layer::RenderLayer};
 
     let mut rl = RenderLayer::default();
@@ -206,13 +206,13 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
     rl.push_with_bag(
         &mut gb,
         FatShape {
-            transform: Affine::IDENTITY,
+            transform: Default::default(),
             paint: FatPaint {
                 stroke: Stroke::new(6.0),
                 stroke_paint: Some(Color::new([0.9804, 0.702, 0.5294, 1.]).into()),
                 fill_paint: None,
             },
-            subshapes: SmallVec::from([RoundedRect::new(10.0, 10.0, 240.0, 240.0, 20.0).into()]),
+            subshapes: Arc::from([RoundedRect::new(10.0, 10.0, 240.0, 240.0, 20.0).into()]),
         },
     );
 
@@ -220,13 +220,13 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
     rl.push_with_bag(
         &mut gb,
         FatShape {
-            transform: Affine::IDENTITY,
+            transform: Default::default(),
             paint: FatPaint {
                 stroke: Default::default(),
                 stroke_paint: None,
                 fill_paint: Some(Color::new([0.9529, 0.5451, 0.6588, 1.]).into()),
             },
-            subshapes: SmallVec::from([Circle::new((420.0, 200.0), 120.0).into()]),
+            subshapes: Arc::from([Circle::new((420.0, 200.0), 120.0).into()]),
         },
     );
 
@@ -234,13 +234,13 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
     rl.push_with_bag(
         &mut gb,
         FatShape {
-            transform: Affine::IDENTITY,
+            transform: Default::default(),
             paint: FatPaint {
                 stroke: Default::default(),
                 stroke_paint: None,
                 fill_paint: Some(Color::new([0.7961, 0.651, 0.9686, 1.]).into()),
             },
-            subshapes: SmallVec::from([Ellipse::new((250.0, 420.0), (100.0, 160.0), -90.0).into()]),
+            subshapes: Arc::from([Ellipse::new((250.0, 420.0), (100.0, 160.0), -90.0).into()]),
         },
     );
 
@@ -248,13 +248,13 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
     rl.push_with_bag(
         &mut gb,
         FatShape {
-            transform: Affine::IDENTITY,
+            transform: Default::default(),
             paint: FatPaint {
                 stroke: Stroke::new(6.0),
                 stroke_paint: Some(Color::new([0.5373, 0.7059, 0.9804, 1.]).into()),
                 fill_paint: None,
             },
-            subshapes: SmallVec::from([Line::new((260.0, 20.0), (620.0, 100.0)).into()]),
+            subshapes: Arc::from([Line::new((260.0, 20.0), (620.0, 100.0)).into()]),
         },
     );
 

--- a/tabulon/src/graphics_bag.rs
+++ b/tabulon/src/graphics_bag.rs
@@ -2,9 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 extern crate alloc;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
+
+use core::num::NonZeroU32;
 
 use crate::{shape::FatShape, text::FatText};
+
+use peniko::kurbo::Affine;
+
+/// A handle for a transform.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TransformHandle(Option<NonZeroU32>);
+
+impl From<TransformHandle> for usize {
+    fn from(h: TransformHandle) -> Self {
+        h.0.map_or(0, |x| x.get() as Self)
+    }
+}
+
+/// Transform record for deriving final transforms.
+#[derive(Debug, Clone, Copy, Default)]
+struct ManagedTransform {
+    /// `TransformHandle` for the parent transform.
+    pub(crate) parent: TransformHandle,
+    pub(crate) local: Affine,
+}
 
 /// Items for [`GraphicsBag`].
 #[derive(Debug)]
@@ -20,10 +42,25 @@ pub enum GraphicsItem {
 }
 
 /// Bag of [`GraphicsItem`]s.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct GraphicsBag {
     /// [`GraphicsItem`]s in the bag.
     pub items: Vec<GraphicsItem>,
+    /// Fully realized transforms used for rendering.
+    final_transforms: Vec<Affine>,
+    /// Records that
+    managed_transforms: Vec<ManagedTransform>,
+}
+
+impl Default for GraphicsBag {
+    fn default() -> Self {
+        Self {
+            // Always initialize with a root transform.
+            final_transforms: vec![Default::default()],
+            managed_transforms: vec![Default::default()],
+            items: Default::default(),
+        }
+    }
 }
 
 impl GraphicsBag {
@@ -37,5 +74,83 @@ impl GraphicsBag {
     /// Get an individual [`GraphicsItem`].
     pub fn get(&self, idx: usize) -> Option<&GraphicsItem> {
         self.items.get(idx)
+    }
+
+    /// Register a transform.
+    ///
+    /// Attach the returned `TransformHandle` to a `GraphicsItem`.
+    pub fn register_transform(
+        &mut self,
+        parent: TransformHandle,
+        local: Affine,
+    ) -> TransformHandle {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "The length of managed_transforms is managed."
+        )]
+        let handle = TransformHandle(NonZeroU32::new(self.managed_transforms.len() as u32));
+        let managed = ManagedTransform { parent, local };
+
+        self.managed_transforms.push(managed);
+
+        self.final_transforms
+            .push(self.final_transforms[usize::from(parent)] * local);
+
+        handle
+    }
+
+    /// Get a transform.
+    pub fn get_transform(&self, handle: TransformHandle) -> Affine {
+        *self.final_transforms.get(usize::from(handle)).unwrap()
+    }
+
+    /// Update a transform.
+    pub fn update_transform(&mut self, handle: TransformHandle, local: Affine) {
+        self.managed_transforms[usize::from(handle)].local = local;
+        self.finalize_transforms(handle);
+    }
+
+    // TODO: Consider finalizing transforms based on a dirty state immediately
+    //       before rendering or picking.
+    /// Update a set of transforms by pairs of `TransformHandle` and local `Affine`.
+    pub fn update_transforms(
+        &mut self,
+        pairs: impl IntoIterator<Item = (TransformHandle, Affine)>,
+    ) {
+        let mut includes_root = false;
+        let mut least = NonZeroU32::MAX;
+        for (k, v) in pairs {
+            self.managed_transforms[usize::from(k)].local = v;
+
+            if let Some(i) = k.0 {
+                least = least.min(i);
+            } else {
+                includes_root = true;
+            }
+        }
+
+        // Empty iterator, do nothing.
+        if least == NonZeroU32::MAX {
+            return;
+        }
+
+        self.finalize_transforms(if includes_root {
+            Default::default()
+        } else {
+            TransformHandle(Some(least))
+        });
+    }
+
+    /// Finalize all transforms that may depend on `handle`.
+    fn finalize_transforms(&mut self, handle: TransformHandle) {
+        for i in usize::from(handle)..self.managed_transforms.len() {
+            let ManagedTransform { parent, local } = self.managed_transforms[i];
+            // Special case for root transform.
+            self.final_transforms[i] = if i == 0 {
+                local
+            } else {
+                self.final_transforms[usize::from(parent)] * local
+            }
+        }
     }
 }

--- a/tabulon/src/lib.rs
+++ b/tabulon/src/lib.rs
@@ -36,8 +36,9 @@ fn ensure_libm_dependency_used() -> f32 {
 
 /// Collection of graphics items.
 pub mod graphics_bag;
+pub use graphics_bag::*;
 
-/// Render layer which lists graphics items in a [`GraphicsBag`](graphics_bag::GraphicsBag) for rendering.
+/// Render layer which lists graphics items in a [`GraphicsBag`] for rendering.
 pub mod render_layer;
 
 /// Shapes for rendering and event dispatch.

--- a/tabulon/src/text.rs
+++ b/tabulon/src/text.rs
@@ -7,15 +7,15 @@ use alloc::sync::Arc;
 
 use parley::{Alignment, StyleSet};
 use peniko::{
-    kurbo::{Affine, Size, Vec2},
+    kurbo::{Size, Vec2},
     Color,
 };
 
-use crate::DirectIsometry;
+use crate::{DirectIsometry, TransformHandle};
 
 /// Reference point where text is attached to an insertion point.
 #[repr(i32)]
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum AttachmentPoint {
     /// Top left corner.
     #[default]
@@ -66,10 +66,10 @@ impl AttachmentPoint {
 }
 
 /// Text item.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FatText {
     /// Primary transform.
-    pub transform: Affine,
+    pub transform: TransformHandle,
     /// Text content.
     pub text: Arc<str>,
     /// Styles for the text.

--- a/tabulon_vello/src/lib.rs
+++ b/tabulon_vello/src/lib.rs
@@ -54,10 +54,10 @@ impl Environment {
                 match $subshape {
                     $(AnyShape::$name(x) =>  {
                         if let Some(fill_paint) = fill_paint {
-                            scene.fill(NonZero, *$transform, fill_paint, None, &x);
+                            scene.fill(NonZero, $transform, fill_paint, None, &x);
                         }
                         if let Some(stroke_paint) = stroke_paint {
-                            scene.stroke(&stroke, *$transform, stroke_paint, None, &x);
+                            scene.stroke(&stroke, $transform, stroke_paint, None, &x);
                         }
                     }),*
                 }
@@ -72,7 +72,9 @@ impl Environment {
                         transform,
                         subshapes,
                     }) => {
-                        for subshape in subshapes {
+                        let transform = graphics.get_transform(*transform);
+
+                        for subshape in subshapes.as_ref() {
                             render_anyshape_match!(
                                 paint,
                                 transform,
@@ -99,6 +101,8 @@ impl Environment {
                         insertion,
                         attachment_point,
                     }) => {
+                        let transform = graphics.get_transform(*transform);
+
                         let mut builder = layout_cx.ranged_builder(font_cx, text, 1.0);
                         for prop in style.inner().values() {
                             builder.push_default(prop.to_owned());
@@ -130,7 +134,7 @@ impl Environment {
                                     // TODO: Color will come from styled text.
                                     .brush(Color::WHITE)
                                     .hint(false)
-                                    .transform(*transform * placement_transform)
+                                    .transform(transform * placement_transform)
                                     .glyph_transform(synthesis.skew().map(|angle| {
                                         Affine::skew(angle.to_radians().tan() as f64, 0.0)
                                     }))


### PR DESCRIPTION
Managed transforms have a four byte `TransformHandle` which is a lot more space efficient than an `Affine` on each item.

tabulon_dxf: Expose entity handles for lines.

vello_viewer: Debug print the `Entity` that was picked, rather than the shape that was picked, this is a step toward surfacing more interesting information to display on screen.