### PR TITLE
tabulon: Be more `no_std`

### DIFF
--- a/tabulon/src/lib.rs
+++ b/tabulon/src/lib.rs
@@ -22,7 +22,7 @@
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![no_std]
 
 #[cfg(all(not(feature = "std"), not(test)))]
 mod floatfuncs;


### PR DESCRIPTION
Instead of having `std` in scope, require bringing it into scope explicitly.

Other crates remain the same as they are now.