### PR TITLE
Use `ItemHandle` for `GraphicsItem`s in `GraphicsBag`.

### DIFF
--- a/tabulon/src/render_layer.rs
+++ b/tabulon/src/render_layer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::{
-    graphics_bag::{GraphicsBag, GraphicsItem},
+    graphics_bag::{GraphicsBag, GraphicsItem, ItemHandle},
     shape::FatShape,
     text::FatText,
 };
@@ -26,12 +26,16 @@ impl From<FatText> for GraphicsItem {
 #[derive(Debug, Default)]
 pub struct RenderLayer {
     /// Collection of [`GraphicsItem`] indices in z order.
-    pub indices: Vec<usize>,
+    pub indices: Vec<ItemHandle>,
 }
 
 impl RenderLayer {
     /// Push a [`GraphicsItem`], returning its index in the bag.
-    pub fn push_with_bag(&mut self, bag: &mut GraphicsBag, i: impl Into<GraphicsItem>) -> usize {
+    pub fn push_with_bag(
+        &mut self,
+        bag: &mut GraphicsBag,
+        i: impl Into<GraphicsItem>,
+    ) -> ItemHandle {
         let n = bag.push(i);
         self.indices.push(n);
         n

--- a/tabulon_dxf/src/lib.rs
+++ b/tabulon_dxf/src/lib.rs
@@ -215,7 +215,7 @@ fn add_poly_segment(bp: &mut BezPath, start: Point, end: Point, bulge: f64) {
     };
 
     arc.to_cubic_beziers(DEFAULT_ACCURACY, |p1, p2, p3| {
-        bp.push(PathEl::CurveTo(p1, p2, p3));
+        bp.curve_to(p1, p2, p3);
     });
 }
 


### PR DESCRIPTION
`usize` is unnecessary, and opaque handles are better for this use.
