### PR TITLE
Put `FatPaint`s in a palette, addressed with `PaintHandle`.

### DIFF
--- a/examples/vello_simple/src/main.rs
+++ b/examples/vello_simple/src/main.rs
@@ -203,57 +203,61 @@ fn add_shapes_to_scene(tv_environment: &mut tabulon_vello::Environment, scene: &
     let mut gb = GraphicsBag::default();
 
     // Draw an outlined rectangle
+    let paint = gb.register_paint(FatPaint {
+        stroke: Stroke::new(6.0),
+        stroke_paint: Some(Color::new([0.9804, 0.702, 0.5294, 1.]).into()),
+        fill_paint: None,
+    });
     rl.push_with_bag(
         &mut gb,
         FatShape {
             transform: Default::default(),
-            paint: FatPaint {
-                stroke: Stroke::new(6.0),
-                stroke_paint: Some(Color::new([0.9804, 0.702, 0.5294, 1.]).into()),
-                fill_paint: None,
-            },
+            paint,
             subshapes: Arc::from([RoundedRect::new(10.0, 10.0, 240.0, 240.0, 20.0).into()]),
         },
     );
 
     // Draw a filled circle
+    let paint = gb.register_paint(FatPaint {
+        stroke: Default::default(),
+        stroke_paint: None,
+        fill_paint: Some(Color::new([0.9529, 0.5451, 0.6588, 1.]).into()),
+    });
     rl.push_with_bag(
         &mut gb,
         FatShape {
             transform: Default::default(),
-            paint: FatPaint {
-                stroke: Default::default(),
-                stroke_paint: None,
-                fill_paint: Some(Color::new([0.9529, 0.5451, 0.6588, 1.]).into()),
-            },
+            paint,
             subshapes: Arc::from([Circle::new((420.0, 200.0), 120.0).into()]),
         },
     );
 
     // Draw a filled ellipse
+    let paint = gb.register_paint(FatPaint {
+        stroke: Default::default(),
+        stroke_paint: None,
+        fill_paint: Some(Color::new([0.7961, 0.651, 0.9686, 1.]).into()),
+    });
     rl.push_with_bag(
         &mut gb,
         FatShape {
             transform: Default::default(),
-            paint: FatPaint {
-                stroke: Default::default(),
-                stroke_paint: None,
-                fill_paint: Some(Color::new([0.7961, 0.651, 0.9686, 1.]).into()),
-            },
+            paint,
             subshapes: Arc::from([Ellipse::new((250.0, 420.0), (100.0, 160.0), -90.0).into()]),
         },
     );
 
     // Draw a straight line
+    let paint = gb.register_paint(FatPaint {
+        stroke: Stroke::new(6.0),
+        stroke_paint: Some(Color::new([0.5373, 0.7059, 0.9804, 1.]).into()),
+        fill_paint: None,
+    });
     rl.push_with_bag(
         &mut gb,
         FatShape {
             transform: Default::default(),
-            paint: FatPaint {
-                stroke: Stroke::new(6.0),
-                stroke_paint: Some(Color::new([0.5373, 0.7059, 0.9804, 1.]).into()),
-                fill_paint: None,
-            },
+            paint,
             subshapes: Arc::from([Line::new((260.0, 20.0), (620.0, 100.0)).into()]),
         },
     );

--- a/tabulon/src/shape.rs
+++ b/tabulon/src/shape.rs
@@ -16,7 +16,7 @@ use crate::floatfuncs::FloatFuncs;
 extern crate alloc;
 use alloc::sync;
 
-use crate::TransformHandle;
+use crate::{PaintHandle, TransformHandle};
 
 /// Enumeration of Kurbo shapes supported in `FatShape`.
 #[derive(Debug, Clone)]
@@ -201,7 +201,7 @@ impl AnyShape {
 }
 
 /// Paint style for [`FatShape`].
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct FatPaint {
     /// Stroke information
     pub stroke: Stroke,
@@ -217,7 +217,7 @@ pub struct FatShape {
     /// Affine transform
     pub transform: TransformHandle,
     /// Paint information
-    pub paint: FatPaint,
+    pub paint: PaintHandle,
     /// [`AnyShape`]s
     pub subshapes: sync::Arc<[AnyShape]>,
 }

--- a/tabulon_vello/src/lib.rs
+++ b/tabulon_vello/src/lib.rs
@@ -73,6 +73,7 @@ impl Environment {
                         subshapes,
                     }) => {
                         let transform = graphics.get_transform(*transform);
+                        let paint = graphics.get_paint(*paint);
 
                         for subshape in subshapes.as_ref() {
                             render_anyshape_match!(


### PR DESCRIPTION
It is common for many items to share a single `FatPaint`, so we should
store them in a palette.

This also further reduces the size of each `GraphicsItem`.