### PR TITLE
Add support for tracing and tracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ env:
   RUST_NO_STD_PKGS: "-p tabulon"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default"
+  # List of features that need native code (no WebAssembly).
+  FEATURES_DEPENDING_ON_NATIVE: "tracing-tracy"
 
 
 # Rationale
@@ -165,13 +167,13 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo clippy (no_std)
-        run: cargo hack clippy ${{ env.RUST_NO_STD_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} -- -D warnings
+        run: cargo hack clippy ${{ env.RUST_NO_STD_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --exclude-features ${{ env.FEATURES_DEPENDING_ON_NATIVE }} -- -D warnings
 
       - name: cargo clippy
-        run: cargo hack clippy --workspace --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std -- -D warnings
+        run: cargo hack clippy --workspace --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std --exclude-features ${{ env.FEATURES_DEPENDING_ON_NATIVE }} -- -D warnings
 
       - name: cargo clippy (auxiliary)
-        run: cargo hack clippy --workspace --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std --tests --benches --examples -- -D warnings
+        run: cargo hack clippy --workspace --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std --exclude-features ${{ env.FEATURES_DEPENDING_ON_NATIVE }} --tests --benches --examples -- -D warnings
 
   test-stable:
     name: cargo test
@@ -221,8 +223,9 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       # TODO: Find a way to make tests work. Until then the tests are merely compiled.
+      # For now, just do the default features.
       - name: cargo test compile
-        run: cargo test --workspace --locked --target wasm32-unknown-unknown --all-features --no-run
+        run: cargo test --workspace --locked --target wasm32-unknown-unknown --no-run
 
   check-msrv:
     name: cargo check (msrv)
@@ -278,7 +281,7 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo check
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std --exclude-features ${{ env.FEATURES_DEPENDING_ON_NATIVE }}
 
   miri:
     name: cargo miri
@@ -303,8 +306,9 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
+      # We'll just run the default features for now.
       - name: cargo miri
-        run: cargo miri test --workspace --locked --all-features --target s390x-unknown-linux-gnu --no-fail-fast
+        run: cargo miri test --workspace --locked --target s390x-unknown-linux-gnu --no-fail-fast
 
   doc:
     name: cargo doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1219,19 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "loop9"
@@ -2716,6 +2742,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tracy"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90a2c01305b02b76fdd89ac8608bae27e173c829a35f7d76a345ab5d33836db"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
+dependencies = [
+ "cc",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +2909,8 @@ dependencies = [
  "tabulon_vello",
  "tracing",
  "tracing-subscriber",
+ "tracing-tracy",
+ "tracy-client",
  "vello",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,5 @@ tabulon_vello = { version = "0.1.0", path = "tabulon_vello", default-features = 
 parley = { version = "0.3.0", default-features = false }
 tracing = { version = "0.1.40", features = ["log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-tracy = "0.11.4"
+tracy-client = "0.18.0"

--- a/examples/vello_viewer/Cargo.toml
+++ b/examples/vello_viewer/Cargo.toml
@@ -8,10 +8,7 @@ repository.workspace = true
 publish = false
 
 [features]
-tracing-tracy = [
-    "dep:tracing-tracy",
-    "dep:tracy-client",
-]
+tracing-tracy = ["dep:tracing-tracy", "dep:tracy-client"]
 
 [dependencies]
 anyhow = "1.0.93"

--- a/examples/vello_viewer/Cargo.toml
+++ b/examples/vello_viewer/Cargo.toml
@@ -7,11 +7,19 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[features]
+tracing-tracy = [
+    "dep:tracing-tracy",
+    "dep:tracy-client",
+]
+
 [dependencies]
 anyhow = "1.0.93"
 pollster = "0.4.0"
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-tracy = { workspace = true, optional = true }
+tracy-client = { workspace = true, optional = true }
 vello = "0.4.0"
 winit = "0.30.8"
 

--- a/examples/vello_viewer/src/main.rs
+++ b/examples/vello_viewer/src/main.rs
@@ -322,6 +322,9 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
 
                 surface_texture.present();
 
+                #[cfg(feature = "tracing-tracy")]
+                tracy_client::frame_mark();
+
                 device_handle.device.poll(wgpu::Maintain::Poll);
 
                 if self.defer_reprojection {
@@ -396,6 +399,12 @@ fn main() -> Result<()> {
                 .with_default_directive(tracing::level_filters::LevelFilter::WARN.into())
                 .from_env_lossy(),
         );
+
+    #[cfg(feature = "tracing-tracy")]
+    let tracy_layer = tracing_tracy::TracyLayer::default();
+    #[cfg(feature = "tracing-tracy")]
+    let subscriber = subscriber.with(tracy_layer);
+
     subscriber.init();
 
     let drawing_load_started = Instant::now();


### PR DESCRIPTION
This can be used by building `vello_viewer` with the `tracing-tracy` feature and then running the tracy client and connecting it once the viewer is running.