### PR TITLE
tabulon_dxf: Render entities to individual items, and do basic culling.

### DIFF
--- a/tabulon/src/graphics_bag.rs
+++ b/tabulon/src/graphics_bag.rs
@@ -14,15 +14,15 @@ use crate::{
 use peniko::kurbo::Affine;
 
 /// A handle for a transform.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub struct TransformHandle(Option<NonZeroU32>);
 
 /// A handle for a `GraphicsItem` in a `GraphicsBag`.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub struct ItemHandle(u32);
 
 /// A handle for a `FatPaint` in a `GraphicsBag`.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub struct PaintHandle(u32);
 
 impl From<PaintHandle> for usize {

--- a/tabulon/src/render_layer.rs
+++ b/tabulon/src/render_layer.rs
@@ -40,4 +40,11 @@ impl RenderLayer {
         self.indices.push(n);
         n
     }
+
+    /// Push an `ItemHandle` into the render layer.
+    pub fn filter(&mut self, f: impl Fn(&ItemHandle) -> bool) -> Self {
+        Self {
+            indices: self.indices.iter().copied().filter(f).collect(),
+        }
+    }
 }

--- a/tabulon/src/shape.rs
+++ b/tabulon/src/shape.rs
@@ -211,7 +211,7 @@ pub struct FatPaint {
 }
 
 /// Collection of subshapes with the same transform and paint style.
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub struct FatShape {
     /// Affine transform
     pub transform: TransformHandle,


### PR DESCRIPTION
View culling pass can not currently cull text items because there is no facility to measure them.

Measuring text items will involve moving a font context into tabulon.
