### PR TITLE
Remove unused `smallvec` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,6 @@ dependencies = [
  "libm",
  "parley",
  "peniko",
- "smallvec",
 ]
 
 [[package]]

--- a/tabulon/Cargo.toml
+++ b/tabulon/Cargo.toml
@@ -23,7 +23,6 @@ libm = ["dep:libm", "peniko/libm", "parley/libm"]
 [dependencies]
 peniko = { version = "0.3.1", default-features = false }
 parley = { workspace = true }
-smallvec = "1.13.2"
 
 [dependencies.libm]
 version = "0.2.11"

--- a/tabulon/src/shape.rs
+++ b/tabulon/src/shape.rs
@@ -8,7 +8,6 @@ use peniko::{
     },
     Brush,
 };
-pub use smallvec::SmallVec;
 
 #[cfg(all(not(feature = "std"), not(test)))]
 use crate::floatfuncs::FloatFuncs;


### PR DESCRIPTION
We don't need to re-export `SmallVec` and this leaves the crate unused within this crate, so remove the dependency for now.