### PR TITLE
tabulon_dxf: Consolidate lines in INSERTs into `BezPath`s.

### DIFF
--- a/tabulon/src/shape.rs
+++ b/tabulon/src/shape.rs
@@ -106,6 +106,25 @@ impl AnyShape {
         )
     }
 
+    /// Returns an iterator over this shape expressed as `PathEl`s; that is, as Bézier path *elements*.
+    pub fn to_path(&self) -> BezPath {
+        impl_any_shape_fun!(
+            self,
+            to_path,
+            DEFAULT_ACCURACY,
+            Arc | BezPath
+                | Circle
+                | CircleSegment
+                | CubicBez
+                | Ellipse
+                | Line
+                | PathSeg
+                | QuadBez
+                | Rect
+                | RoundedRect
+        )
+    }
+
     /// `true` if given point is inside the shape.
     pub fn contains(&self, p: Point) -> bool {
         impl_any_shape_fun!(


### PR DESCRIPTION
This allows larger drawings to be viewed at default scale, since most large drawings lean heavily on INSERTs.

vello_viewer: Because INSERTs often span large distances and include many lines, it was necessary to decompose items into `PathSeg`s for computing the AABB index used for culling and picking. 
This allows enclosing INSERTs to be culled for viewing, and not included in picking calculations when none of their lines are near the cursor.

The picking logic is also improved, and does about half as much work (due to only computing `nearest` once).

The AABB index's indexing precision is reduced to `f32`, which makes it more efficient in space and time.