### PR TITLE
Move `workspace.dependencies` section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 # Tabulon version, also used by other packages which want to mimic Tabulon's version.
 #
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
-#       version in the dependencies section at the bottom of this file.
+#       version in the `workspace.dependencies` section in this file.
 version = "0.1.0"
 
 edition = "2021"
@@ -21,6 +21,17 @@ edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/tabulon"
+
+[workspace.dependencies]
+tabulon = { version = "0.1.0", path = "tabulon", default-features = false }
+tabulon_dxf = { version = "0.1.0", path = "tabulon_dxf" }
+tabulon_vello = { version = "0.1.0", path = "tabulon_vello", default-features = false }
+
+parley = { version = "0.3.0", default-features = false }
+tracing = { version = "0.1.40", default-features = false, features = ["attributes", "log"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-tracy = "0.11.4"
+tracy-client = "0.18.0"
 
 [workspace.lints]
 rust.unsafe_code = "deny"
@@ -69,14 +80,3 @@ clippy.negative_feature_names = "warn"
 clippy.redundant_feature_names = "warn"
 clippy.wildcard_dependencies = "warn"
 # END LINEBENDER LINT SET
-
-[workspace.dependencies]
-tabulon = { version = "0.1.0", path = "tabulon", default-features = false }
-tabulon_dxf = { version = "0.1.0", path = "tabulon_dxf" }
-tabulon_vello = { version = "0.1.0", path = "tabulon_vello", default-features = false }
-
-parley = { version = "0.3.0", default-features = false }
-tracing = { version = "0.1.40", default-features = false, features = ["attributes", "log"] }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-tracing-tracy = "0.11.4"
-tracy-client = "0.18.0"


### PR DESCRIPTION
Trying this out on the various repos since the lints is big and unchanging and the same across most repos, so we don't need to have it in the middle of the interesting parts.