### PR TITLE
tabulon_dxf: Attach color paints to text items.

### DIFF
--- a/tabulon/src/text.rs
+++ b/tabulon/src/text.rs
@@ -11,7 +11,7 @@ use peniko::{
     Color,
 };
 
-use crate::{DirectIsometry, TransformHandle};
+use crate::{DirectIsometry, PaintHandle, TransformHandle};
 
 /// Reference point where text is attached to an insertion point.
 #[repr(i32)]
@@ -70,6 +70,10 @@ impl AttachmentPoint {
 pub struct FatText {
     /// Primary transform.
     pub transform: TransformHandle,
+    /// Paint.
+    ///
+    /// Only fills are used currently.
+    pub paint: PaintHandle,
     /// Text content.
     pub text: Arc<str>,
     /// Styles for the text.

--- a/tabulon_dxf/src/lib.rs
+++ b/tabulon_dxf/src/lib.rs
@@ -944,7 +944,10 @@ pub fn load_file_default_layers(path: impl AsRef<Path>) -> DxfResult<TDDrawing> 
         // Get or create the appropriate PaintHandle for this entity.
         let entity_paint = resolve_paint(
             &mut gb,
-            if matches!(e.specific, EntityType::Solid(..)) {
+            if matches!(
+                e.specific,
+                EntityType::Solid(..) | EntityType::Text(..) | EntityType::MText(..)
+            ) {
                 // Use `i16::MIN` for solid fills.
                 i16::MIN
             } else {
@@ -1088,6 +1091,7 @@ pub fn load_file_default_layers(path: impl AsRef<Path>) -> DxfResult<TDDrawing> 
                     &mut gb,
                     FatText {
                         transform: Default::default(),
+                        paint: entity_paint,
                         text: nt.into(),
                         // TODO: Map more styling information from the MText
                         style: styles.get(mt.text_style_name.as_str()).map_or_else(
@@ -1146,6 +1150,7 @@ pub fn load_file_default_layers(path: impl AsRef<Path>) -> DxfResult<TDDrawing> 
                     &mut gb,
                     FatText {
                         transform: Default::default(),
+                        paint: entity_paint,
                         text: text.into(),
                         style: styles.get(t.text_style_name.as_str()).map_or_else(
                             || StyleSet::new(t.text_height as f32),

--- a/tabulon_vello/src/lib.rs
+++ b/tabulon_vello/src/lib.rs
@@ -70,6 +70,7 @@ impl Environment {
                     }
                     GraphicsItem::FatText(FatText {
                         transform,
+                        paint,
                         text,
                         style,
                         max_inline_size,
@@ -94,6 +95,14 @@ impl Environment {
                         let placement_transform = Affine::from(*insertion)
                             * Affine::translate(-attachment_point.select(layout_size));
 
+                        let FatPaint {
+                            fill_paint: Some(fill_paint),
+                            ..
+                        } = graphics.get_paint(*paint)
+                        else {
+                            continue;
+                        };
+
                         for line in layout.lines() {
                             for item in line.items() {
                                 let PositionedLayoutItem::GlyphRun(glyph_run) = item else {
@@ -107,7 +116,7 @@ impl Environment {
                                 scene
                                     .draw_glyphs(run.font())
                                     // TODO: Color will come from styled text.
-                                    .brush(Color::BLACK)
+                                    .brush(fill_paint)
                                     .hint(false)
                                     .transform(transform * placement_transform)
                                     .glyph_transform(synthesis.skew().map(|angle| {


### PR DESCRIPTION
tabulon: Add paint to `FatText`.

tabulon_vello: Render color paints from `FatText`

dxf_viewer: Light adapt all paints in drawing.