### PR TITLE
tabulon_dxf: Reexport dxf crate.

### DIFF
--- a/tabulon_dxf/src/lib.rs
+++ b/tabulon_dxf/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! DXF loader for Tabulon
 
+pub use dxf;
 use dxf::{Drawing, DxfResult, entities::EntityType};
 
 use tabulon::{


### PR DESCRIPTION
In the future this will be handled by a drawing types crate.